### PR TITLE
Improving HTML and PHP highlighting

### DIFF
--- a/colors/janah.vim
+++ b/colors/janah.vim
@@ -140,4 +140,9 @@ highlight StartifySpecial guifg=#585858 ctermfg=240 guibg=NONE ctermbg=NONE gui=
 highlight TermCursor ctermfg=NONE guibg=#ff00af ctermbg=199 gui=NONE cterm=NONE
 highlight TermCursorNC ctermfg=NONE guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 
+" HTML {{{1
+
+highlight link htmlTagN htmlTagName
+
+
 let g:colors_name = 'janah'

--- a/colors/janah.vim
+++ b/colors/janah.vim
@@ -144,5 +144,15 @@ highlight TermCursorNC ctermfg=NONE guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 
 highlight link htmlTagN htmlTagName
 
+" PHP {{{1
+
+highlight link phpVarSelector Normal
+highlight link phpIdentifier Normal
+highlight link phpParent Normal
+highlight phpDefine guifg=#ffaf87 ctermfg=216 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+highlight phpFunctions guifg=#ffdfaf ctermfg=223 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+highlight phpSpecialFunction guifg=#ffdfaf ctermfg=223 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+highlight phpMethods guifg=#ffdfaf ctermfg=223 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+highlight phpMethodsVar guifg=#ffdfaf ctermfg=223 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 
 let g:colors_name = 'janah'


### PR DESCRIPTION
Hi Marco, thanks for the colorscheme! I've been using `janah` for the past week and I missed two things: highlighting on custom HTML tags and a, in general, better PHP syntax highlighting. Are you interested in file type specific rules?

PHP's before and after:
![before-after](https://user-images.githubusercontent.com/6828028/45601549-2c7f7500-b9e5-11e8-8337-68d6a8d076cf.png)
